### PR TITLE
Revert Runtime update & icon rename

### DIFF
--- a/de.akaflieg_freiburg.enroute.json
+++ b/de.akaflieg_freiburg.enroute.json
@@ -1,10 +1,9 @@
 {
     "app-id": "de.akaflieg_freiburg.enroute",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-21.08",
+    "runtime-version": "5.15",
     "sdk": "org.kde.Sdk",
     "command": "enroute",
-    "rename-icon": "enroute",
     "finish-args": [
         "--share=ipc",
         "--share=network",


### PR DESCRIPTION
Both commits are breaking the builds. Let's revert them from now to fix
it while we figure it out.

Revert: d043442 Update runtime to 5.15-21.08
Revert: 2c38b5a Fix icon renaming